### PR TITLE
fix: move JSX comment out of Image attribute list

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -73,6 +73,8 @@ const { headline, tagline, focus } = intro[lang];
     </div>
 
     <div class="rise order-first md:order-last">
+      {/* No fetchpriority="high" — the LCP element is the h1, so the portrait
+          must not compete with the preloaded Inter file. */}
       <Image
         src={portrait}
         alt={site.legalName}
@@ -80,8 +82,6 @@ const { headline, tagline, focus } = intro[lang];
         height={260}
         densities={[1, 2]}
         loading="eager"
-        {/* No fetchpriority="high" — the LCP element is the h1, so the portrait
-            must not compete with the preloaded Inter file. */}
         class="size-32 rounded-2xl border border-border object-cover sm:size-40 md:size-60"
       />
     </div>


### PR DESCRIPTION
`main` currently fails `npm run check`, which fails the Cloudflare deploy at `.github/workflows/deploy.yml:33`.

`src/components/Hero.astro` had a `{/* ... */}` comment sitting between the `loading` and `class` attributes of `<Image>`. Astro parses an element attribute list as HTML, not JSX, so `{/*` was read as literal attribute text and left the preceding string unterminated:

```
src/components/Hero.astro:87:5 - error ts(1005): ':' expected.
src/components/Hero.astro:86:9 - error ts(1002): Unterminated string literal.
```

Same comment, hoisted to markup level immediately above the element, where the expression form is valid and is still stripped from the built output.

Verified locally: `astro check` 0 errors, `astro build` 23 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)