### PR TITLE
chore: bump actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,9 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -35,7 +35,8 @@ jobs:
       - run: npm run build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        # v4 installs Wrangler v4 by default instead of pinning v3.90.0.
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
`actions/checkout@v4` and `actions/setup-node@v4` target Node 20, which runners now force onto Node 24 with a deprecation warning on every run. v5 of each moved to Node 24 natively; this goes to current majors rather than the minimum that clears the warning.

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `cloudflare/wrangler-action` | v3 | v4 |

## Breaking changes, checked against this workflow

- **setup-node v5** — auto-caches when `package.json` has a `packageManager` field. Ours does not, and `cache: npm` is set explicitly regardless.
- **setup-node v6** — limits automatic caching to npm. This is an npm project.
- **checkout v5 / setup-node v5** — require runner ≥ v2.327.1. GitHub-hosted runners are well past that.
- **checkout v7** — blocks fork checkouts for `pull_request_target` and `workflow_run`. This workflow triggers on `pull_request`.
- **wrangler-action v4** — installs Wrangler v4 instead of pinning v3.90.0. The Pages project was created with Wrangler 4.118.0, so `pages deploy` is already exercised on v4.

This PR's own run is the test: it exercises every bumped action and ends in a preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)