### PR TITLE
Trim the résumé summaries

### DIFF
--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -44,7 +44,7 @@ export const experience: Record<Lang, Role[]> = {
       summary:
         "Designing healthcare analytics pipelines across on-premise and cloud environments with BigQuery, Dataform, Python, PostgreSQL and MySQL, plus the operational dashboards and reporting that clinical and business teams decide on. Also contributing to GCP and Microsoft cloud migration work, and writing the documentation that keeps the systems usable without me.",
       highlights: [
-        "Designed and implemented healthcare analytics pipelines on BigQuery, Dataform, Python, PostgreSQL and MySQL, across on-premise and cloud environments.",
+        "Designed and implemented healthcare analytics pipelines on BigQuery, Dataform, Python, PostgreSQL and MySQL.",
         "Built the operational dashboards and analytical reporting that clinical and business stakeholders decide on.",
         "Contributed to cloud migration work across the GCP and Microsoft ecosystems, improving infrastructure scalability and operational efficiency.",
         "Wrote the technical documentation and worked directly with healthcare teams to reduce operational friction around the systems.",
@@ -151,7 +151,7 @@ export const experience: Record<Lang, Role[]> = {
       end: null,
       place: "Remoto",
       summary:
-        "Desenvolvimento de pipelines de analytics em saúde entre ambientes on-premise e nuvem com BigQuery, Dataform, Python, PostgreSQL e MySQL, além dos dashboards operacionais e relatórios em que times clínicos e de negócio se apoiam para decidir. Também contribuo nas migrações para GCP e ecossistema Microsoft, e escrevo a documentação que mantém os sistemas utilizáveis sem depender de mim.",
+        "Desenvolvimento de pipelines de analytics em saúde com BigQuery, Dataform, Python, PostgreSQL e MySQL, além dos dashboards operacionais e relatórios em que times clínicos e de negócio se apoiam para decidir. Também contribuo nas migrações para GCP e ecossistema Microsoft, e escrevo a documentação que mantém os sistemas utilizáveis sem depender de mim.",
       highlights: [
         "Projetei e implementei pipelines de analytics em saúde com BigQuery, Dataform, Python, PostgreSQL e MySQL, entre ambientes on-premise e nuvem.",
         "Construí os dashboards operacionais e os relatórios analíticos em que times clínicos e de negócio se apoiam para decidir.",

--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -41,7 +41,7 @@ export interface ResumeContent {
 export const resume: Record<Lang, ResumeContent> = {
   en: {
     summary:
-      "Full Stack Software Engineer with 3+ years designing and delivering scalable web and mobile applications serving 10,000+ daily active users, data pipelines, and cloud-native systems. Product engineering, modern frontend and backend architecture, data engineering, and infrastructure automation — with a track record of building end-to-end systems, leading technical initiatives, and shipping products that stay shipped.",
+      "Full Stack Software Engineer with 3+ years designing and delivering scalable web and mobile applications serving 10,000+ daily active users, data pipelines, and cloud-native systems. Product engineering, modern frontend and backend architecture, data engineering, and infrastructure automation — with a track record of building end-to-end systems.",
     skills: [
       { label: "Languages", items: ["TypeScript", "JavaScript", "Python", "C#", "SQL"] },
       { label: "Frontend", items: ["React", "Next.js", "Angular", "Flutter", "HTML", "CSS"] },
@@ -98,7 +98,7 @@ export const resume: Record<Lang, ResumeContent> = {
   },
   "pt-br": {
     summary:
-      "Engenheiro de Software Full Stack com 3+ anos projetando e entregando aplicações web e mobile escaláveis que atendem mais de 10.000 usuários ativos por dia, pipelines de dados e sistemas cloud-native. Engenharia de produto, arquitetura moderna de frontend e backend, engenharia de dados e automação de infraestrutura — com histórico de construir sistemas de ponta a ponta, conduzir iniciativas técnicas e entregar produtos que continuam de pé.",
+      "Engenheiro de Software Full Stack com 3+ anos projetando e entregando aplicações web e mobile escaláveis, pipelines de dados e sistemas cloud-native. Engenharia de produto, arquitetura moderna de frontend e backend, engenharia de dados e automação de infraestrutura — com histórico de construir sistemas de ponta a ponta.",
     skills: [
       { label: "Linguagens", items: ["TypeScript", "JavaScript", "Python", "C#", "SQL"] },
       { label: "Frontend", items: ["React", "Next.js", "Angular", "Flutter", "HTML", "CSS"] },


### PR DESCRIPTION
Small copy cuts to the professional summary in both locales, plus a shorter Informar Saúde pipeline bullet.

Both PDFs still render 2 A4 pages.

## Two asymmetries worth a look

**The 10,000+ daily active users claim now appears in the English résumé but not the Portuguese one.** Counted in the build: `resume/index.html` has it, `pt-br/resume/index.html` does not. Both homepages still carry it. If the cut was deliberate, fine — but it was previously a deliberate decision to keep that figure on every surface rather than soften or drop it, so flagging in case it went with the trim by accident.

**The on-premise/cloud detail swapped places between locales.** EN dropped it from the résumé bullet and keeps it in the timeline summary; PT dropped it from the timeline summary and keeps it in the résumé bullet. So the English PDF no longer mentions on-prem/cloud and the Portuguese one still does.

Neither blocks the deploy; both are one-line fixes if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)